### PR TITLE
Change the way to spawn dummy

### DIFF
--- a/Content/Characters/MainCharacter/MainCharacterComponents/Abilities/BP_DummyAbilityComponent.uasset
+++ b/Content/Characters/MainCharacter/MainCharacterComponents/Abilities/BP_DummyAbilityComponent.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:63e608acb6f517d9afae385fdc9c3fbbf204c73ac450347e3720ac969fa18cc1
-size 439445
+oid sha256:440c196e9c44a11edddaeca6517bdbd7adb369bd90a07265cdea3a9cbb85779e
+size 451907


### PR DESCRIPTION
The dummy spawn when left click is released and is destroy when right click is pressed. Right click also remove the projection without spawning the dummy