### PR TITLE
Fix Pickable Clue Texture

### DIFF
--- a/Content/Levels/SubLevels/Forest/Blueprints/Machine/BP_PickableClue.uasset
+++ b/Content/Levels/SubLevels/Forest/Blueprints/Machine/BP_PickableClue.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0f0a3591f36fdbc528a879f0000d2e1decc00fe83e40426fd1871bd4144b5531
-size 104960
+oid sha256:21e5ae90e8b07f11ed7c8315b78c2d256ec4cad90960f9afd14ee2d378e3142a
+size 107026


### PR DESCRIPTION
Create material instance in begin play instead of start highlight event