### PR TITLE
Fix cpp compilation on MacOs

### DIFF
--- a/Source/Base/Portal.cpp
+++ b/Source/Base/Portal.cpp
@@ -2,7 +2,7 @@
 
 
 #include "Portal.h"
-#include "Components/StaticMeshComponent.h "
+#include "Components/StaticMeshComponent.h"
 #include "Components/SceneCaptureComponent2D.h"
 #include "Engine/TextureRenderTarget2D.h"
 #include "FPCharacter.h"


### PR DESCRIPTION
MacOs do not like space after .h path :)