### PR TITLE
Fix SD Bug - Desert Music doesn't play at respawn

### DIFF
--- a/Content/FMOD/SoundLevel.umap
+++ b/Content/FMOD/SoundLevel.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4f70b81956b305e411d1778478ec2232acdd13806c58dc7bff5adf1c9a999234
-size 32432
+oid sha256:1726e176646d40de93558465c1c2f3aca8784b47cfd8343ab241edd380f21ed6
+size 31630

--- a/Content/Levels/SubLevels/Chambre2/Chambre.umap
+++ b/Content/Levels/SubLevels/Chambre2/Chambre.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d45a4d3fb4bb718e09f8ef8482591eb876e95e14e9cdb46116f41f595d8a0d3d
-size 489896
+oid sha256:c344e28580ba0b3a8642f703d5dde9a6fdd6308d33fd610770b3cc216d2b0792
+size 489708


### PR DESCRIPTION
I Just move a sound trigger volume in chamber (the 1st one), so there is no more overlap conflict in the desert once we respawn.