### PR TITLE
Remove vinyle puzzle in ChambreFinal and ChambreRespawn

### DIFF
--- a/Content/Levels/SubLevels/Chambre2/Blueprints/VinylePlayer/BP_VinylePlayer.uasset
+++ b/Content/Levels/SubLevels/Chambre2/Blueprints/VinylePlayer/BP_VinylePlayer.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9e03f2c2c3408c5f9a4d4dea0c2e4735b32cbbf456fdf0e476597b59a8f49683
-size 596129
+oid sha256:163847afe1175c9371cd0426107b3c06232674eadc60d609bb44fbfb2083adcf
+size 600589

--- a/Content/Levels/SubLevels/Chambre2/ChambreFinal.umap
+++ b/Content/Levels/SubLevels/Chambre2/ChambreFinal.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fefd6a619a68d9ee452e41fdc25452d497d333d653350e7d10578b45e2863e90
-size 440150
+oid sha256:6f1d07c0964a288eaae8a029c3aaa2a9fb7ba4195699feea17f9e4d7dcc59655
+size 426941

--- a/Content/Levels/SubLevels/Chambre2/ChambreRespawn.umap
+++ b/Content/Levels/SubLevels/Chambre2/ChambreRespawn.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:01bb66b0108f77dc2c85152486b6e13fc1d6789cf67893c827dd994bc2f9dd5a
-size 535316
+oid sha256:4e53f9ba966b835affb8de06ad7b9b4eacd75242d0ea97ea2c05b9a0bd32f18c
+size 518737

--- a/Content/Levels/SubLevels/Chambre2/RoomMechanics/Armoire/BP_VinyleCommodeDrawerSimple.uasset
+++ b/Content/Levels/SubLevels/Chambre2/RoomMechanics/Armoire/BP_VinyleCommodeDrawerSimple.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df5f123f8f55d3fbb1ad8c3a817a50ff71195a92b8ebd1ad68243255caab58a0
+size 58716

--- a/Content/Levels/SubLevels/Chambre2/RoomMechanics/BP_VinyleCommodeSimple.uasset
+++ b/Content/Levels/SubLevels/Chambre2/RoomMechanics/BP_VinyleCommodeSimple.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a0df1642f1ea66283e0766811fd81783763aef2722df7e8c77fe933e60eeade
+size 126978


### PR DESCRIPTION
Il n'y a plus l'avancement de l'énigme des vinyles dans la chambre respawn et finale. J'ai laissé l'interaction avec la platine à vinyle (je trouvais ça sympa et je ne voyais de grands inconvénients à la garder). Par contre les leds du tiroir ne s'allument plus, et ce dernier est déjà déverrouillé (et vide). Il n'y a aussi plus de cadenas, et les portes du bas sont aussi déverrouillées.