### PR TITLE
Fix Missing string table entry

### DIFF
--- a/Config/DefaultGame.ini
+++ b/Config/DefaultGame.ini
@@ -100,6 +100,7 @@ bSkipMovies=False
 +DirectoriesToAlwaysCook=(Path="/Game/FMOD/Reverbs")
 +DirectoriesToAlwaysCook=(Path="/Game/FMOD/Snapshots")
 +DirectoriesToAlwaysCook=(Path="/Game/FMOD/VCAs")
++DirectoriesToAlwaysCook=(Path="/Game/UI/Localization/ST_BoxedText.ST_BoxedTex")
 +DirectoriesToAlwaysStageAsNonUFS=(Path="FMOD/Desktop")
 PerPlatformBuildConfig=(("Windows", PPBC_Shipping))
 PerPlatformTargetFlavorName=(("Android", "Android_ASTC"))
@@ -109,4 +110,16 @@ PerPlatformBuildTarget=()
 bWaitForMoviesToComplete=True
 bMoviesAreSkippable=False
 +StartupMovies=UE_still_logo_v04_4k
+
+[/Script/Engine.AssetManagerSettings]
+-PrimaryAssetTypesToScan=(PrimaryAssetType="Map",AssetBaseClass=/Script/Engine.World,bHasBlueprintClasses=False,bIsEditorOnly=True,Directories=((Path="/Game/Maps")),SpecificAssets=,Rules=(Priority=-1,ChunkId=-1,bApplyRecursively=True,CookRule=Unknown))
+-PrimaryAssetTypesToScan=(PrimaryAssetType="PrimaryAssetLabel",AssetBaseClass=/Script/Engine.PrimaryAssetLabel,bHasBlueprintClasses=False,bIsEditorOnly=True,Directories=((Path="/Game")),SpecificAssets=,Rules=(Priority=-1,ChunkId=-1,bApplyRecursively=True,CookRule=Unknown))
++PrimaryAssetTypesToScan=(PrimaryAssetType="Map",AssetBaseClass="/Script/Engine.World",bHasBlueprintClasses=False,bIsEditorOnly=True,Directories=((Path="/Game/Maps")),SpecificAssets=("/Game/UI/Localization/ST_BoxedText.ST_BoxedText"),Rules=(Priority=-1,ChunkId=-1,bApplyRecursively=True,CookRule=Unknown))
++PrimaryAssetTypesToScan=(PrimaryAssetType="PrimaryAssetLabel",AssetBaseClass="/Script/Engine.PrimaryAssetLabel",bHasBlueprintClasses=False,bIsEditorOnly=True,Directories=((Path="/Game")),SpecificAssets=,Rules=(Priority=-1,ChunkId=-1,bApplyRecursively=True,CookRule=Unknown))
+bOnlyCookProductionAssets=False
+bShouldManagerDetermineTypeAndName=False
+bShouldGuessTypeAndNameInEditor=True
+bShouldAcquireMissingChunksOnLoad=False
+bShouldWarnAboutInvalidAssets=True
+MetaDataTagsForAssetRegistry=()
 


### PR DESCRIPTION
- Add asset in Packaging > Additional Asset Directories to Cook
- Add asset in Asset Manager > Specific Assets