### PR TITLE
Fix Desert Shadow

### DIFF
--- a/Content/Levels/SubLevels/Desert/DesertTemp.umap
+++ b/Content/Levels/SubLevels/Desert/DesertTemp.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b8cae87fe9a23b3e301a74a379c0ff29895184c8c12c3dd8d37e1fc4923d2238
-size 2642367
+oid sha256:af5926e393bb3e5c5c06d003175e12b7942649ee7f3e8e91b37e7966da0648f0
+size 2641034


### PR DESCRIPTION
En fait, le problème des ombres du désert semble venir du fait que le landscape était affecté par ses propres ombres. J'ai juste désactivé le fait que le landscape projette des ombres. 

De mon côté, cela à résolu le soucis.